### PR TITLE
Fix path to the command interpreter

### DIFF
--- a/bin/mapbox-geostats
+++ b/bin/mapbox-geostats
@@ -1,4 +1,4 @@
-#!usr/bin/env node
+#!/usr/bin/env node
 
 /* eslint-disable no-console */
 var meow = require('meow');


### PR DESCRIPTION
The module was failing on my machine after running a global install: `npm install -g mapbox-geostats`. This is due to a missing '/' on the first line of the executable script.

cc: @davidtheclark 