### PR TITLE
[Tag fiesta] bump file-sniff and switch to ~ for deps using C++ modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# 0.3.0
+
+* Upgrade mapbox-file-sniff@0.5.2
+* Use ~ instead of ^ for node-mbtiles and node-mapnik

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/mapbox/mapbox-geostats#readme",
   "dependencies": {
     "lodash": "^4.13.1",
-    "mapbox-file-sniff": "git://github.com/mapbox/mapbox-file-sniff.git#smelloscope",
+    "mapbox-file-sniff": "https://github.com/mapbox/mapbox-file-sniff/tarball/smelloscope",
     "mapnik": "~3.5.14",
     "mbtiles": "~0.9.0",
     "meow": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.2.1",
   "description": "Generate statistics about geographic data.",
   "main": "index.js",
-  "engines": {
-    "node": ">=4"
-  },
   "bin": {
     "mapbox-geostats": "bin/mapbox-geostats"
   },
@@ -26,12 +23,12 @@
   "homepage": "https://github.com/mapbox/mapbox-geostats#readme",
   "dependencies": {
     "lodash": "^4.13.1",
-    "mapbox-file-sniff": "^0.5.0",
-    "mapnik": "^3.5.13",
-    "mbtiles": "^0.8.2",
+    "mapbox-file-sniff": "git://github.com/mapbox/mapbox-file-sniff.git#smelloscope",
+    "mapnik": "~3.5.14",
+    "mbtiles": "~0.9.0",
     "meow": "^3.7.0",
     "pbf": "^2.0.1",
-    "tilelive": "^5.12.2",
+    "tilelive": "~5.12.2",
     "tiletype": "^0.3.0",
     "vector-tile": "^1.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/mapbox/mapbox-geostats#readme",
   "dependencies": {
     "lodash": "^4.13.1",
-    "mapbox-file-sniff": "https://github.com/mapbox/mapbox-file-sniff/tarball/smelloscope",
+    "mapbox-file-sniff": "~0.5.2",
     "mapnik": "~3.5.14",
     "mbtiles": "~0.9.0",
     "meow": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.13.1",
     "mapbox-file-sniff": "git://github.com/mapbox/mapbox-file-sniff.git#smelloscope",
     "mapnik": "~3.5.14",
-    "mbtiles": "^0.8.2",
+    "mbtiles": "~0.9.0",
     "meow": "^3.7.0",
     "pbf": "^2.0.1",
     "tilelive": "~5.12.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.13.1",
     "mapbox-file-sniff": "git://github.com/mapbox/mapbox-file-sniff.git#smelloscope",
     "mapnik": "~3.5.14",
-    "mbtiles": "~0.9.0",
+    "mbtiles": "^0.8.2",
     "meow": "^3.7.0",
     "pbf": "^2.0.1",
     "tilelive": "~5.12.2",


### PR DESCRIPTION
Per https://github.com/mapbox/versioning-node-cpp we want to use ~ for deps that contain C++ modules (to avoid dupes of those modules).

This also brings in latest file-sniff.