### PR TITLE
Update to 1.0.0, update mapnik version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# 0.6.0
+# 1.0.0
 
 - Upgrade to mapnik 3.7.0
+- Drops windows support
 
 # 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.0
+
+- Upgrade to mapnik 3.7.0
+
 # 0.5.1
 
 - Fix issue where tile-analyze Promise was not finishing execution on resolve [#34](https://github.com/mapbox/mapbox-geostats/issues/34)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-geostats",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Generate statistics about geographic data.",
   "main": "index.js",
   "bin": {
@@ -30,7 +30,7 @@
     "@mapbox/vector-tile": "^1.2.1",
     "jsonschema": "^1.1.1",
     "lodash": "^4.13.1",
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "meow": "^3.7.0",
     "pbf": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-geostats",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "Generate statistics about geographic data.",
   "main": "index.js",
   "bin": {

--- a/test/fixtures/expected/geojson-invalid-geometry-types.json
+++ b/test/fixtures/expected/geojson-invalid-geometry-types.json
@@ -1,0 +1,21 @@
+{
+  "layerCount": 1,
+  "layers": [
+    {
+      "layer": "geometry-invalid-types",
+      "count": 1,
+      "attributeCount": 1,
+      "attributes": [
+        {
+          "values": [
+            "bar"
+          ],
+          "count": 1,
+          "attribute": "foo",
+          "type": "string"
+        }
+      ],
+      "geometry": "Point"
+    }
+  ]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -221,12 +221,15 @@ test('invalid GeoJSON', t => {
   });
 });
 
-test('GeoJSON fails with invalid geometry type', t => {
-  geostats(fixturePath('src/geometry-invalid-types.geojson')).then((output) => {
-    t.fail(output);
-  }).catch(err => {
-    t.ok(err, 'errored');
+test('GeoJSON skips invalid geometry types', t => {
+  Promise.all([
+    geostats(fixturePath('src/geometry-invalid-types.geojson')),
+    getExpected('geojson-invalid-geometry-types'),
+  ]).then((output) => {
+    t.deepEqual(output[0], output[1], 'expected geostats');
     t.end();
+  }).catch((err) => {
+    t.fail(err);
   });
 });
 


### PR DESCRIPTION
Bump to `1.0.0`, drops windows support due to bump to mapnik `3.7.0` dropping support for windows. 